### PR TITLE
COR-2112: Send 4xx error codes to user

### DIFF
--- a/client.go
+++ b/client.go
@@ -90,8 +90,8 @@ func (c *client) Confirm(adId string, displayTime int64) (string, error) {
 		return "", AdNotFound
 	}
 
-	c.pop.Confirm(ad, displayTime)
-	return ad["original_asset_url"].(string), nil
+	err := c.pop.Confirm(ad, displayTime)
+	return ad["original_asset_url"].(string), err
 }
 
 func (c *client) GetAd(config AdConfig, req *AdRequest) (

--- a/client.go
+++ b/client.go
@@ -80,8 +80,8 @@ func (c *client) Expire(adId string) error {
 		return AdNotFound
 	}
 
-	c.pop.Expire(ad)
-	return nil
+	err := c.pop.Expire(ad)
+	return err
 }
 
 func (c *client) Confirm(adId string, displayTime int64) (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,4 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
-	gopkg.in/matryer/try.v1 v1.0.0-20150601225556-312d2599e12e
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,3 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-gopkg.in/matryer/try.v1 v1.0.0-20150601225556-312d2599e12e h1:bJHzu9Qwc9wQRWJ/WVkJGAfs+riucl/tKAFNxf9pzqk=
-gopkg.in/matryer/try.v1 v1.0.0-20150601225556-312d2599e12e/go.mod h1:tve0rTLdGlwnXF7iBO9rbAEyeXvuuPx0n4DvXS/Nw7o=

--- a/proof_of_play.go
+++ b/proof_of_play.go
@@ -113,7 +113,7 @@ func (p *proofOfPlay) start() {
 				p.processRequestFailure(req, err)
 			}
 		} else {
-			err := p.expire(req.Ad)
+			err := p.expire(req)
 			if err != nil {
 				p.processRequestFailure(req, err)
 			}

--- a/proof_of_play.go
+++ b/proof_of_play.go
@@ -189,7 +189,6 @@ func (p *proofOfPlay) confirm(popReq *PoPRequest) error {
 		return err
 	}
 
-	aid := ad["id"].(string)
 	err = try.Do(func(attempt int) (bool, error) {
 		req, err := http.NewRequest("POST", confirmUrl, bytes.NewBuffer(data))
 		if err != nil {
@@ -205,11 +204,7 @@ func (p *proofOfPlay) confirm(popReq *PoPRequest) error {
 			}
 
 			p.processRequestFailure(popReq, err)
-			return false, &PoPError{
-				AdId:    aid,
-				Status:  http.StatusInternalServerError,
-				Message: fmt.Sprintf("%s", err),
-			}
+			return false, nil
 		}
 
 		shouldRetry, err := p.processResponse("pop", adId, resp)
@@ -220,7 +215,7 @@ func (p *proofOfPlay) confirm(popReq *PoPRequest) error {
 			}
 
 			p.processRequestFailure(popReq, err)
-			return false, err
+			return false, nil
 		}
 
 		defer resp.Body.Close()

--- a/proof_of_play.go
+++ b/proof_of_play.go
@@ -139,7 +139,7 @@ func (p *proofOfPlay) makePoPRequest(req *http.Request,
 		return &PoPError{
 			Status: http.StatusAccepted,
 			Message: fmt.Sprintf(
-				"Connection Error, Request will be Retried: %s", err.Error()),
+				"Connection error, request will be retried: %s", err.Error()),
 		}
 	}
 
@@ -175,7 +175,7 @@ func (p *proofOfPlay) makePoPRequest(req *http.Request,
 	err = &PoPError{
 		Status: http.StatusAccepted,
 		Message: fmt.Sprintf(
-			"Ad server responded %d. Request will be Retried.", code),
+			"Ad server responded %d: request will be retried.", code),
 	}
 	p.processRequestFailure(popReq, err)
 	return err

--- a/proof_of_play.go
+++ b/proof_of_play.go
@@ -47,18 +47,19 @@ func NewTestProofOfPlay() *testProofOfPlay {
 	return &testProofOfPlay{requests: make([]*PoPRequest, 0, 0)}
 }
 
-func (t *testProofOfPlay) Expire(ad Ad) {
-	t.requests = append(t.requests, &PoPRequest{Ad: ad, Status: false})
-}
-
 func (t *testProofOfPlay) Stop() {
 }
 
-func (t *testProofOfPlay) Confirm(ad Ad, displayTime int64) {
-	t.requests = append(t.requests, &PoPRequest{
-		Ad:          ad,
-		Status:      true,
-		DisplayTime: displayTime})
+func (t *testProofOfPlay) Confirm(ad Ad, displayTime int64) error {
+	t.requests = append(
+		t.requests,
+		&PoPRequest{Ad: ad, Status: false, DisplayTime: displayTime})
+	return nil
+}
+
+func (t *testProofOfPlay) Expire(ad Ad) error {
+	t.requests = append(t.requests, &PoPRequest{Ad: ad, Status: true})
+	return nil
 }
 
 type proofOfPlay struct {


### PR DESCRIPTION
This PR is incomplete and still needs tests. Wanted your opinion as in order to return a non-200 status code, we have to change the way we consume PoP requests. Consuming using channels does not allow us to return an error response if the ad server returns an error or if there is any other request error.

A couple of questions/notes:
- Do we still need to retry 3x on every PoP request if we are also processing retries in a retry queue? If a server responds 500 or receive a connection error, we retry 3x w/ a 10s delay between each, which means that the requester will only receive a response after 30s, which seems long.
- I think I could refactor this further to use only one channel for retries instead of using both requests and retryQueue channel, but leaving this in for simplicity for now.

https://vistarmedia.atlassian.net/browse/COR-2112

@hkaya @sheshnath08 