### PR TITLE
COR-2470: Remove hide pop/expiration URL util

### DIFF
--- a/client.go
+++ b/client.go
@@ -129,12 +129,12 @@ func (c *client) GetAd(config AdConfig, req *AdRequest) (
 	}
 
 	if c.cacheFn == nil {
-		return c.hidePopUrl(resp), nil
+		return resp, nil
 	}
 
 	c.cacheAds(resp)
 	cleanedResponse := c.tryToExpireAds(resp)
-	return c.hidePopUrl(cleanedResponse), nil
+	return cleanedResponse, nil
 }
 
 func (c *client) GetAssets(config AdConfig, req *AdRequest) (
@@ -233,21 +233,6 @@ func (c *client) tryToExpireAds(resp *AdResponse) *AdResponse {
 		cleaned.Advertisement = append(cleaned.Advertisement, ad)
 	}
 	return cleaned
-}
-
-func (c *client) hidePopUrl(resp *AdResponse) *AdResponse {
-	response := &AdResponse{}
-	for _, ad := range resp.Advertisement {
-		processedAd := make(Ad)
-		for key, value := range ad {
-			if key == "proof_of_play_url" || key == "expiration_url" {
-				continue
-			}
-			processedAd[key] = value
-		}
-		response.Advertisement = append(response.Advertisement, processedAd)
-	}
-	return response
 }
 
 func (c *client) addToInProgressList(ad Ad) {

--- a/client_test.go
+++ b/client_test.go
@@ -160,44 +160,6 @@ func TestTryToExpireAds(t *testing.T) {
 	assert.Equal(t, pop.requests[0].Ad["asset_url"], "url1")
 }
 
-func TestHidePopUrl(t *testing.T) {
-	resp := &AdResponse{
-		Advertisement: []Ad{
-			map[string]interface{}{
-				"id":                "1",
-				"asset_url":         "url1",
-				"proof_of_play_url": "http://pop-url",
-			},
-			map[string]interface{}{
-				"id":             "2",
-				"asset_url":      "url2",
-				"expiration_url": "http://exire-url",
-			},
-			map[string]interface{}{
-				"id":                "3",
-				"asset_url":         "url2",
-				"expiration_url":    "http://exire-url",
-				"proof_of_play_url": "http://pop-url",
-			},
-		},
-	}
-
-	pop := NewTestProofOfPlay()
-	client := &client{pop: pop}
-
-	nresp := client.hidePopUrl(resp)
-	assert.Len(t, nresp.Advertisement, 3)
-	assert.Equal(t, nresp.Advertisement[0]["id"], "1")
-	assert.NotContains(t, nresp.Advertisement[0], "proof_of_play_url")
-	assert.NotContains(t, nresp.Advertisement[0], "expiration_url")
-	assert.Equal(t, nresp.Advertisement[1]["id"], "2")
-	assert.NotContains(t, nresp.Advertisement[1], "proof_of_play_url")
-	assert.NotContains(t, nresp.Advertisement[1], "expiration_url")
-	assert.Equal(t, nresp.Advertisement[2]["id"], "3")
-	assert.NotContains(t, nresp.Advertisement[2], "proof_of_play_url")
-	assert.NotContains(t, nresp.Advertisement[2], "expiration_url")
-}
-
 func TestRemoveExpiredAds(t *testing.T) {
 	ad1 := map[string]interface{}{
 		"id":           "1",


### PR DESCRIPTION
 With this change we are no longer hiding Pop/exipration url from the ad response.