### PR TITLE
update ad request to set asset cache endpoint url in constructor.

### DIFF
--- a/config.go
+++ b/config.go
@@ -38,6 +38,8 @@ type Request interface {
 	ServerUrl() string
 	AssetEndpointUrl() string
 	AssetEndpointDisplayAreas() []DisplayArea
+	LogLevel() int64
+	LogEnabled() bool
 }
 
 type request struct {
@@ -49,22 +51,15 @@ type request struct {
 	url                       string
 }
 
-func NewRequest(url string, data *Data, logEnabled bool,
-	logLevel int64) *request {
+func NewRequest(url string, assetEndpointUrl string, data *Data,
+	logEnabled bool, logLevel int64) *request {
 	return &request{
-		url:        url,
-		data:       data,
-		logEnabled: logEnabled,
-		logLevel:   logLevel,
+		url:              url,
+		assetEndpointUrl: assetEndpointUrl,
+		data:             data,
+		logEnabled:       logEnabled,
+		logLevel:         logLevel,
 	}
-}
-
-func (r *request) SetAssetEndpointUrl(url string) {
-	r.assetEndpointUrl = url
-}
-
-func (r *request) SetAssetEndpointDisplayAreas(displayAreas []DisplayArea) {
-	r.assetEndpointDisplayAreas = displayAreas
 }
 
 func (r request) Data() *Data {

--- a/config_test.go
+++ b/config_test.go
@@ -8,43 +8,34 @@ import (
 
 func TestAdRequestData(t *testing.T) {
 	adRequestData := &Data{}
-	request := NewRequest("url.com", adRequestData, true, int64(0))
+	request := NewRequest("url.com", "", adRequestData, true, int64(0))
 
 	assert.Equal(t, adRequestData, request.Data())
 }
 
 func TestServerUrl(t *testing.T) {
-	request := NewRequest("ad-server-url.com", nil, true, int64(0))
+	request := NewRequest("ad-server-url.com", "", nil, true, int64(0))
 	assert.Equal(t, request.ServerUrl(), "ad-server-url.com")
 }
 
 func TestLogEnabled(t *testing.T) {
-	request := NewRequest("", nil, true, int64(0))
+	request := NewRequest("", "", nil, true, int64(0))
 	assert.True(t, request.LogEnabled())
 
-	request = NewRequest("", nil, false, int64(0))
+	request = NewRequest("", "", nil, false, int64(0))
 	assert.False(t, request.LogEnabled())
 }
 
 func TestLogLevel(t *testing.T) {
-	request := NewRequest("", nil, true, int64(0))
+	request := NewRequest("", "", nil, true, int64(0))
 	assert.Equal(t, request.LogLevel(), int64(0))
 
-	request = NewRequest("", nil, true, int64(2))
+	request = NewRequest("", "", nil, true, int64(2))
 	assert.Equal(t, request.LogLevel(), int64(2))
 }
 
 func TestSetAssetEndpointUrl(t *testing.T) {
-	request := NewRequest("", nil, true, int64(0))
-	request.SetAssetEndpointUrl("asset-url.com")
+	request := NewRequest("", "asset-url.com", nil, true, int64(0))
 
 	assert.Equal(t, request.AssetEndpointUrl(), "asset-url.com")
-}
-
-func TestSetAssetEndpointDisplayAreas(t *testing.T) {
-	var displayAreas []DisplayArea
-	request := NewRequest("", nil, true, int64(0))
-	request.SetAssetEndpointDisplayAreas(displayAreas)
-
-	assert.Equal(t, request.AssetEndpointDisplayAreas(), displayAreas)
 }


### PR DESCRIPTION
Also, Add LogLevel() and LogEnabled() getter method to the interface.